### PR TITLE
Circuit 에 nav3 를 맥이려는 시도

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Samplemvi"
+        android:enableOnBackInvokedCallback="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/example/sample_mvi/MainActivity.kt
+++ b/app/src/main/java/com/example/sample_mvi/MainActivity.kt
@@ -6,13 +6,22 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
 import com.example.sample_mvi.core.common.circuit.CircuitScreen
+import com.example.sample_mvi.core.common.circuit.rememberCircuitNav3Navigator
 import com.example.sample_mvi.core.common.ui.theme.SamplemviTheme
+import com.example.sample_mvi.features.detail.DetailPresenter
+import com.example.sample_mvi.features.detail.DetailScreen
+import com.example.sample_mvi.features.detail.DetailUiFactory
 import com.example.sample_mvi.features.example.ExamplePresenter
 import com.example.sample_mvi.features.example.ExampleScreen
 import com.example.sample_mvi.features.example.ExampleUiFactory
 import com.slack.circuit.runtime.presenter.presenterOf
+import com.slack.circuit.runtime.screen.Screen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -20,20 +29,49 @@ class MainActivity : ComponentActivity() {
 
         enableEdgeToEdge()
         setContent {
+
             SamplemviTheme {
+                val backStack = rememberSaveable { mutableStateListOf<Screen>(ExampleScreen) }
+                val navigator = rememberCircuitNav3Navigator(backStack)
+
                 Scaffold { paddingValues ->
-                    CircuitScreen {
-                        presenter<ExampleScreen, ExampleScreen.State> { screen ->
-                            presenterOf { ExamplePresenter() }
+                    NavDisplay(
+                        backStack = backStack,
+                        onBack = { backStack.removeLastOrNull() },
+                        entryProvider = entryProvider {
+                            entry<ExampleScreen> {
+                                CircuitScreen {
+                                    presenter<ExampleScreen, ExampleScreen.State> { screen, navigator ->
+                                        presenterOf { ExamplePresenter(navigator) }
+                                    }
+
+                                    ui(ExampleUiFactory())
+
+                                    content(
+                                        screen = ExampleScreen,
+                                        modifier = Modifier.padding(paddingValues),
+                                        navigator = navigator
+                                    )
+                                }
+                            }
+
+                            entry<DetailScreen> {
+                                CircuitScreen {
+                                    presenter<DetailScreen, DetailScreen.State> { screen, navigator ->
+                                        presenterOf { DetailPresenter() }
+                                    }
+
+                                    ui(DetailUiFactory())
+
+                                    content(
+                                        screen = DetailScreen,
+                                        modifier = Modifier.padding(paddingValues),
+                                        navigator = navigator
+                                    )
+                                }
+                            }
                         }
-
-                        ui(ExampleUiFactory())
-
-                        content(
-                            screen = ExampleScreen,
-                            modifier = Modifier.padding(paddingValues)
-                        )
-                    }
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/sample_mvi/core/common/circuit/CircuitBuilder.kt
+++ b/app/src/main/java/com/example/sample_mvi/core/common/circuit/CircuitBuilder.kt
@@ -6,6 +6,7 @@ import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.CircuitContent
 import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.ui.Ui
@@ -15,11 +16,11 @@ open class CircuitScope {
     private lateinit var content: @Composable () -> Unit
 
     inline fun <reified S : Screen, UiState : CircuitUiState> presenter(
-        crossinline factory: (screen: S) -> Presenter<UiState>
+        crossinline factory: (screen: S, navigator: Navigator) -> Presenter<UiState>
     ) = apply {
-        circuit.addPresenterFactory { screen, _, _ ->
+        circuit.addPresenterFactory { screen, navigator, _ ->
             if (screen is S) {
-                factory(screen)
+                factory(screen, navigator)
             } else {
                 null
             }
@@ -31,8 +32,14 @@ open class CircuitScope {
         circuit.addUiFactory(factory)
     }
 
-    fun content(screen: Screen, modifier: Modifier = Modifier) {
-        content = { CircuitContent(screen, modifier) }
+    fun content(screen: Screen, modifier: Modifier = Modifier, navigator: Navigator) {
+        content = {
+            CircuitContent(
+                screen = screen,
+                modifier = modifier,
+                navigator = navigator
+            )
+        }
     }
 
     @Composable

--- a/app/src/main/java/com/example/sample_mvi/core/common/circuit/CircuitNav3Navigator.kt
+++ b/app/src/main/java/com/example/sample_mvi/core/common/circuit/CircuitNav3Navigator.kt
@@ -1,0 +1,44 @@
+package com.example.sample_mvi.core.common.circuit
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.screen.PopResult
+import com.slack.circuit.runtime.screen.Screen
+
+class CircuitNav3Navigator(
+    private val backStack: MutableList<Screen> = mutableListOf()
+) : Navigator {
+
+    override fun goTo(screen: Screen): Boolean {
+        return backStack.add(screen)
+    }
+
+    override fun peek(): Screen? {
+        return backStack.lastOrNull()
+    }
+
+    override fun peekBackStack(): List<Screen> {
+        return backStack.toList()
+    }
+
+    override fun pop(result: PopResult?): Screen? {
+        return backStack.removeLastOrNull()
+    }
+
+    override fun resetRoot(
+        newRoot: Screen,
+        options: Navigator.StateOptions
+    ): List<Screen> {
+        backStack.clear()
+        backStack.add(newRoot)
+        return backStack
+    }
+}
+
+@Composable
+fun rememberCircuitNav3Navigator(backStack: MutableList<Screen> = mutableListOf()) = remember(backStack) {
+    CircuitNav3Navigator(backStack)
+}
+
+

--- a/app/src/main/java/com/example/sample_mvi/features/detail/DetailContract.kt
+++ b/app/src/main/java/com/example/sample_mvi/features/detail/DetailContract.kt
@@ -1,0 +1,19 @@
+package com.example.sample_mvi.features.detail
+
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.screen.Screen
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data object DetailScreen : Screen {
+    data class State(
+        val content: String = "Hello, world"
+    ) : CircuitUiState
+
+    sealed interface Event : CircuitUiEvent {
+
+    }
+}
+
+

--- a/app/src/main/java/com/example/sample_mvi/features/detail/DetailPresenter.kt
+++ b/app/src/main/java/com/example/sample_mvi/features/detail/DetailPresenter.kt
@@ -1,0 +1,10 @@
+package com.example.sample_mvi.features.detail
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun DetailPresenter(): DetailScreen.State {
+    return DetailScreen.State(
+        content = "Hello, world"
+    )
+}

--- a/app/src/main/java/com/example/sample_mvi/features/detail/DetailScreen.kt
+++ b/app/src/main/java/com/example/sample_mvi/features/detail/DetailScreen.kt
@@ -1,0 +1,40 @@
+package com.example.sample_mvi.features.detail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.slack.circuit.runtime.CircuitContext
+import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.runtime.ui.Ui
+import com.slack.circuit.runtime.ui.ui
+
+@Composable
+fun DetailScreen(
+    modifier: Modifier = Modifier,
+    state: DetailScreen.State,
+) {
+    Box(modifier) {
+        Column {
+            Text(text = state.content)
+        }
+    }
+}
+
+class DetailUiFactory : Ui.Factory {
+    override fun create(
+        screen: Screen,
+        context: CircuitContext
+    ): Ui<*>? {
+        return when(screen) {
+            is DetailScreen -> {
+                ui<DetailScreen.State> { state, modifier ->
+                    DetailScreen(modifier.fillMaxSize(), state)
+                }
+            }
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/example/sample_mvi/features/example/ExampleContract.kt
+++ b/app/src/main/java/com/example/sample_mvi/features/example/ExampleContract.kt
@@ -11,13 +11,14 @@ data object ExampleScreen : Screen {
         val isLoading: Boolean = false,
         val data: String = "",
         val errorMessage: String = "",
-        val eventSink: (Event) -> Unit
+        val eventSink: (Event) -> Unit = {}
     ) : CircuitUiState
 
     sealed interface Event : CircuitUiEvent {
         data class RequestData(val data: String) : Event
         data class Error(val message: String) : Event
         data class ShowToast(val message: String) : Event
+        object NavigateToDetail : Event
     }
 }
 

--- a/app/src/main/java/com/example/sample_mvi/features/example/ExamplePresenter.kt
+++ b/app/src/main/java/com/example/sample_mvi/features/example/ExamplePresenter.kt
@@ -5,12 +5,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import com.example.sample_mvi.features.detail.DetailScreen
 import com.slack.circuit.retained.rememberRetained
+import com.slack.circuit.runtime.Navigator
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
-fun ExamplePresenter(): ExampleScreen.State {
+fun ExamplePresenter(
+    navigator: Navigator
+): ExampleScreen.State {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -34,6 +38,9 @@ fun ExamplePresenter(): ExampleScreen.State {
             }
             is ExampleScreen.Event.Error -> errorMessage.value = event.message
             is ExampleScreen.Event.ShowToast -> { Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show() }
+            is ExampleScreen.Event.NavigateToDetail -> {
+                navigator.goTo(DetailScreen)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/sample_mvi/features/example/ExampleScreen.kt
+++ b/app/src/main/java/com/example/sample_mvi/features/example/ExampleScreen.kt
@@ -27,6 +27,12 @@ fun ExampleScreen(
                 Text("Fetch Data")
             }
             Text(text = state.data)
+
+            Button(onClick = {
+                state.eventSink(ExampleScreen.Event.NavigateToDetail)
+            }) {
+                Text("Go To Detail")
+            }
         }
 
         if(state.isLoading) {


### PR DESCRIPTION
## Circuit에 Nav3 를 먹여보자 
Circuit 은 일반적으로 자체 제공하는 Navigation 로직을 타도록 안내되어있다.
실제 내부 코드에도 Navigator 를 직접적으로 의존하며, 자체 네비게이션 로직과 강하게 결합되어있는 것처럼 보인다.

그러나, 다행인지 Circuit에서 제공하는 Navigator 는 interface를 public 하게 오픈하고 있다.
```kotlin
@Stable
public interface Navigator : GoToNavigator {
  public override fun goTo(screen: Screen): Boolean

  public fun pop(result: PopResult? = null): Screen?
  public fun peek(): Screen?
  public fun peekBackStack(): List<Screen>
//...
}
```

이걸 직접 구현해서 Nav3의 BackStack 을 조작할 수 있도록 implementation 해주면 되겠다.
```kotlin
class CircuitNav3Navigator(
    private val backStack: MutableList<Screen> = mutableListOf()
) : Navigator {

    override fun goTo(screen: Screen): Boolean {
        return backStack.add(screen)
    }

    override fun peek(): Screen? {
        return backStack.lastOrNull()
    }

    override fun peekBackStack(): List<Screen> {
        return backStack.toList()
    }

    override fun pop(result: PopResult?): Screen? {
        return backStack.removeLastOrNull()
    }

    override fun resetRoot(
        newRoot: Screen,
        options: Navigator.StateOptions
    ): List<Screen> {
        backStack.clear()
        backStack.add(newRoot)
        return backStack
    }
}
```

### Navigator 구현은 ㅇㅋ, 이제 어떻게 CircuitContent 와 엮을 수 있겠는가? 
기본적인 틀은 Nav3로 하되, 세부적인 각각 entry 는 `CircuitContent` 로 구현해주면 될 것 같았다.
대충 의사코드로 나타내면 다음과 같다.

```kotlin
NavDisplay {
    entry<Screen1> { CircuitContent(Screen1) }
    entry<Screen2> { CircuitContent(Screen2) } 
}
```

근데 Nav3 는 뭔가 entry 를 메인 액티비티에서 구현하기가 싫다.
Feature 모듈에서 유연하게 함수형으로 깔끔하게 정리하고 싶다. (멀티모듈 아키텍쳐에서 Nav2 부터 써온 사람들은 이게 어떤말인지 이해가 갈것같다.)
```kotlin
fun screen1Route() {
    entry<Screen1> { ... }
}
```

이것도 가능할 것 같으나, Circuit 은 Presenter와 UI 레이어를 필수적으로 구현해야하나, 이를 MainActivity에서 Factory를 넘겨주어 중앙제어하는 방식을 사용한다. 

이는 결합도가 높아진다 판단하여 직접 Builder 패턴을 구현하여 각 화면별로 Presenter, UI 를 별도 적용하도록 구현했다.
```kotlin
entry<ExampleScreen> {
    CircuitScreen {
        presenter<ExampleScreen, ExampleScreen.State> { screen, navigator ->
            presenterOf { ExamplePresenter(navigator) }
        }

        ui(ExampleUiFactory())

        content(
            screen = ExampleScreen,
            modifier = Modifier.padding(paddingValues),
            navigator = navigator
        )
    }
}
```

이렇게 하면 각각 화면별로 Presenter와 UI 를 각각 구현하면서도 Nav3 로 떼어낼 수도 있다.
그러나 빌더 내부적으로 Circuit을 매번 다시구현하게 되는데 이 패턴이 효율적인지는 모르겠다. 

명확한 단점은 화면 단위의 보일러 플레이트가 생긴다.
그러나 크리티컬한 이슈는 아니고 참고 견딜만한 단점으로 보임

### 동작
매우 잘된다 !! 
predictive back gesture 도 스무스하게 잘먹는다. 

### rememberRetained 에 대한 의문
nav3 backStack을 circuit의 rememberRetained 로 감싸서 정의하면 구성변경시 백스택이 유지되지 않는다.
rememberRetained의 내부 구현을 잘 알지 못해서 rememberSaveable 을 사용했다. 
이건 나중에 공부해보기로 한당


# 총평
기존 mvi 를 구현하고자 하면, Event -> SideEffect -> Reducing 순서의 UDF 파이프라인자체를 직접 구현해주어야 한다. 
여기서 각 Feature별로 레이어들을 직접 타이핑해서 구현해주어야하는데, Circuit은 이러한 과정을 추상화하여 개발자들이 쉽게 직관적인 코드퀄리티로 UDF를 구현할 수 있도록 도와주는 것으로 느꼈다.

(이 레포는 기존 mvi 에서 circuit 으로 마이그레이션할 경우 어느정도의 러닝커브와 공수가 들어가야할지 가늠하기 위해서 만들었던 프로젝트이다.)

여기까지 Circuit에 대해서 문서 기반의 찍먹을 해보았다. 
다음은 어떻게 동작하는지 검토와 분석을 진행할 에정이다.

최근 현생 이슈로 개발공부가 소홀했는데, 한 번 풀어지면 다시 돌아오기가 쉽지 않다. 
그래서 매일 1일 1커밋하는 이유도 가느다란 정신줄정도는 잡아두려고 하는것도 있다.
여하튼,,^^ 이게 도대체 pr이야 일기야 싶겠지만 오랜만에 제대로된 학습을 한 것 같아서 즐겁당